### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/trevSmart/rally-node/security/code-scanning/1](https://github.com/trevSmart/rally-node/security/code-scanning/1)

To address the issue, you should add a `permissions` block to the workflow YAML, either at the root or at the job level, specifying least privilege. Since all jobs here (there's only one job: `build-and-test`) only need to read the repository contents, we should set `contents: read`. Do this by adding:

- Either at the top level (applies to all jobs):  
  ```
  permissions:
    contents: read
  ```
  Add this between the `name:` block and the `on:` block.

- Or, as a more local fix (if only fixing the detected job):  
  ```
  permissions:
    contents: read
  ```
  Immediately after `runs-on: ubuntu-latest` within the `build-and-test` job.

The best fix for simplicity and future safety is to add this at the root level, immediately after the `name:` block. No dependencies or imports required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
